### PR TITLE
Question Pool Get API Data bug fix and quiz Category Get API Sorting Bug Fix

### DIFF
--- a/QuizVerse.Application/Core/Service/QuizCategoryService.cs
+++ b/QuizVerse.Application/Core/Service/QuizCategoryService.cs
@@ -36,21 +36,28 @@ public class QuizCategoryService(IGenericRepository<QuizCategory> _quizCategoryR
         // Validate Sort Column
         if (!string.IsNullOrEmpty(pageListRequest.SortColumn))
         {
-            bool columnExists = typeof(QuizCategory).GetProperty(
-                 pageListRequest.SortColumn,
-                 BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance
-                 
-             ) != null;
             if (pageListRequest.SortColumn.ToLower() == "quizcount")
             {
                 pageListRequest.SortColumn = "Quizzes.Count()";
-                columnExists = true;
             }
-            if (!columnExists)
+
+            // Check if property exists
+            var propertyInfo = typeof(QuizCategory).GetProperty(
+                pageListRequest.SortColumn,
+                BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance
+            );
+
+            if (propertyInfo == null && pageListRequest.SortColumn != "Quizzes.Count()")
             {
                 throw new ArgumentException(
                     string.Format(Constants.INVALID_COLUMN_NAME, pageListRequest.SortColumn),
                     nameof(pageListRequest.SortColumn));
+            }
+
+            // If the property is boolean, invert the sort direction
+            if (propertyInfo?.PropertyType == typeof(bool))
+            {
+                pageListRequest.SortDescending = !pageListRequest.SortDescending;
             }
  
             quizCategories = quizCategories.OrderBy($"{pageListRequest.SortColumn} {(pageListRequest.SortDescending ? "desc" : "asc")}");

--- a/QuizVerse.Infrastructure/DTOs/ResponseDTOs/QueOptionsAndAnsDto.cs
+++ b/QuizVerse.Infrastructure/DTOs/ResponseDTOs/QueOptionsAndAnsDto.cs
@@ -1,9 +1,15 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace QuizVerse.Infrastructure.DTOs.ResponseDTOs;
 
 public class QueOptionsAndAnsDto
 {
+    [Column("id")]
     public int Id { get; set; }
+    [Column("questionId")]
     public int QuestionId { get; set; }
+    [Column("key")]
     public string Key { get; set; } = null!;
+    [Column("value")]
     public string Value { get; set; } = null!;
 }

--- a/QuizVerse.Infrastructure/DTOs/ResponseDTOs/QuestionPoolListDto.cs
+++ b/QuizVerse.Infrastructure/DTOs/ResponseDTOs/QuestionPoolListDto.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json;
 
 namespace QuizVerse.Infrastructure.DTOs.ResponseDTOs;
 
@@ -20,6 +21,15 @@ public class QuestionPoolListDto
     public int QueTypeId { get; set; }
     [Column("que_type_name")]
     public string QueTypeName { get; set; } = null!;
+    [Column("que_options_ans")]
+    public string? QueOptionsAnsJson { get; set; }
+
     [NotMapped]
-    public List<QueOptionsAndAnsDto> QueOptionsAns { get; set; } = new();
+    public List<QueOptionsAndAnsDto> QueOptionsAns =>
+     string.IsNullOrWhiteSpace(QueOptionsAnsJson)
+         ? new()
+         : JsonSerializer.Deserialize<List<QueOptionsAndAnsDto>>(
+             QueOptionsAnsJson,
+             new JsonSerializerOptions { PropertyNameCaseInsensitive = true }
+           )!;
 }

--- a/QuizVerse.UnitTests/Services/QuizCategoryServiceTest.cs
+++ b/QuizVerse.UnitTests/Services/QuizCategoryServiceTest.cs
@@ -220,5 +220,100 @@ namespace QuizVerse.UnitTests.Services
             Assert.Equal(2, result.Records.Count);
             Assert.Equal("Zoology", result.Records[0].CategoryName);
         }
+
+        [Fact]
+        public async Task GetQuizCategories_WithQuizCountSort_ShouldSortByQuizCount()
+        {
+            // Arrange
+            var quizCategories = new List<QuizCategory>
+            {
+                new QuizCategory { Id = 1, CategoryName = "Math", Description = "Math", Quizzes = new List<Quiz> { new Quiz(), new Quiz() } },
+                new QuizCategory { Id = 2, CategoryName = "Science", Description = "Sci", Quizzes = new List<Quiz>() }
+            }.AsQueryable();
+
+            var request = new PageListRequest
+            {
+                PageNumber = 1,
+                PageSize = 10,
+                SortColumn = "QuizCount",
+                SortDescending = true
+            };
+
+            var pagedResult = new PageListResponse<QuizCategory>
+            {
+                Records = quizCategories.OrderByDescending(q => q.Quizzes.Count).ToList(),
+                TotalRecords = quizCategories.Count()
+            };
+
+            _quizCategoryRepoMock.Setup(r => r.GetQueryableInclude(It.IsAny<Expression<Func<QuizCategory, object>>>()))
+                .Returns(quizCategories);
+
+            _quizCategoryRepoMock.Setup(r => r.PaginatedList<QuizCategory>(It.IsAny<IQueryable<QuizCategory>>(), request, null))
+                .ReturnsAsync(pagedResult);
+
+            _mapperMock.Setup(m => m.Map<List<QuizCategoryDTO>>(pagedResult.Records))
+                .Returns(pagedResult.Records.Select(q => new QuizCategoryDTO
+                {
+                    Id = q.Id,
+                    CategoryName = q.CategoryName,
+                    Description = q.Description
+                }).ToList());
+
+            // Act
+            var result = await _service.GetQuizCategories(request);
+
+            // Assert
+            Assert.Equal(2, result.Records.Count);
+            Assert.Equal("Math", result.Records[0].CategoryName); // Math has 2 quizzes, Science has 0
+            Assert.Equal(2, result.Records[0].QuizCount);
+            Assert.Equal(0, result.Records[1].QuizCount);
+        }
+
+        [Fact]
+        public async Task GetQuizCategories_BooleanSortColumn_ShouldInvertSortDirection()
+        {
+            // Arrange
+            var quizCategories = new List<QuizCategory>
+            {
+                new QuizCategory { Id = 1, CategoryName = "Math", Status = true, Quizzes = new List<Quiz>() },
+                new QuizCategory { Id = 2, CategoryName = "Science", Status = false, Quizzes = new List<Quiz>() }
+            }.AsQueryable();
+
+            var request = new PageListRequest
+            {
+                PageNumber = 1,
+                PageSize = 10,
+                SortColumn = "Status",
+                SortDescending = false // This should get inverted inside the method
+            };
+
+            var pagedResult = new PageListResponse<QuizCategory>
+            {
+                Records = quizCategories.OrderByDescending(q => q.Status).ToList(),
+                TotalRecords = quizCategories.Count()
+            };
+
+            _quizCategoryRepoMock.Setup(r => r.GetQueryableInclude(It.IsAny<Expression<Func<QuizCategory, object>>>()))
+                .Returns(quizCategories);
+
+            _quizCategoryRepoMock.Setup(r => r.PaginatedList<QuizCategory>(It.IsAny<IQueryable<QuizCategory>>(), request, null))
+                .ReturnsAsync(pagedResult);
+
+            _mapperMock.Setup(m => m.Map<List<QuizCategoryDTO>>(pagedResult.Records))
+                .Returns(pagedResult.Records.Select(q => new QuizCategoryDTO
+                {
+                    Id = q.Id,
+                    CategoryName = q.CategoryName,
+                    IsActive = q.Status
+                }).ToList());
+
+            // Act
+            var result = await _service.GetQuizCategories(request);
+
+            // Assert
+            Assert.Equal(2, result.Records.Count);
+            Assert.True(result.Records[0].IsActive); // Should come first due to descending order after inversion
+            Assert.False(result.Records[1].IsActive);
+        }
     }
 }


### PR DESCRIPTION
IN this PR i have Done Question Pool Get API Data bug fix and quiz Category Get API Sorting Bug Fix.


IN Question Pool Data Before
<img width="1423" height="761" alt="image" src="https://github.com/user-attachments/assets/7ed13a89-1f0a-4654-8670-a829f3775180" />
After
<img width="1302" height="404" alt="{E4012B3A-7F5A-42DF-B7F2-60B941666B50}" src="https://github.com/user-attachments/assets/9ea6ae79-4ba0-41c2-a4fd-e15aab37edde" />


In Quiz Category Before(with same request condition)
<img width="800" height="274" alt="image" src="https://github.com/user-attachments/assets/b5a9c5de-819a-4d2f-9a9a-d3319b6b39d0" />
After
<img width="1457" height="483" alt="{F50EB7C4-A292-48B1-8CA0-48BF6B7A17C5}" src="https://github.com/user-attachments/assets/608a8f3d-b711-4def-b4db-33c2c384d37b" />
