### PR TITLE
Complete the API for the list of email templates with sorting functionality

### DIFF
--- a/QuizVerse.Application/Core/Interface/IEmailTemplatesService.cs
+++ b/QuizVerse.Application/Core/Interface/IEmailTemplatesService.cs
@@ -1,6 +1,9 @@
+using QuizVerse.Infrastructure.DTOs.RequestDTOs;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+
 namespace QuizVerse.Application.Core.Interface;
 
 public interface IEmailTemplatesService
 {
-    
+    PageListResponse<EmailTemplatesResponseDto> GetAllEmailTemplates(PageListRequest pageListRequest);
 }

--- a/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
+++ b/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
@@ -22,16 +22,11 @@ public class EmailTemplatesService(IGenericRepository<EmailTemplete> emailTempla
             var propertyInfo = typeof(EmailTemplete).GetProperty(
                 pageListRequest.SortColumn,
                 BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance
-            );
-
-            if (propertyInfo == null)
-            {
-                throw new AppException(
+            ) ?? throw new AppException(
                     string.Format(Constants.INVALID_COLUMN_NAME, pageListRequest.SortColumn),400);
-            }
 
             // If the property is boolean, invert the sort direction
-            if (propertyInfo?.PropertyType == typeof(bool))
+            if (propertyInfo.PropertyType == typeof(bool))
             {
                 pageListRequest.SortDescending = !pageListRequest.SortDescending;
             }
@@ -42,15 +37,13 @@ public class EmailTemplatesService(IGenericRepository<EmailTemplete> emailTempla
             emailTempletes = emailTempletes.OrderBy(q => q.Id);
         }
 
-        List<EmailTemplete> emailTempletesList = emailTempletes.ToList();
-
-        List<EmailTemplatesResponseDto> emailTemplatesResponse = _mapper.Map<List<EmailTemplatesResponseDto>>(emailTempletesList);
+        List<EmailTemplatesResponseDto> emailTemplatesResponse = _mapper.Map<List<EmailTemplatesResponseDto>>(emailTempletes.ToList());
 
 
         return new PageListResponse<EmailTemplatesResponseDto>
         {
             Records = emailTemplatesResponse,
-            TotalRecords = emailTempletesList.Count(),
+            TotalRecords = emailTemplatesResponse.Count(),
         };
     }
 }

--- a/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
+++ b/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
@@ -1,8 +1,56 @@
+using System.Reflection;
 using QuizVerse.Application.Core.Interface;
+using QuizVerse.Domain.Entities;
+using QuizVerse.Infrastructure.Common;
+using QuizVerse.Infrastructure.DTOs.RequestDTOs;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+using QuizVerse.Infrastructure.Interface;
+using System.Linq.Dynamic.Core;
+using AutoMapper;
+using QuizVerse.Infrastructure.Common.Exceptions;
 
 namespace QuizVerse.Application.Core.Service;
 
-public class EmailTemplatesService() : IEmailTemplatesService
+public class EmailTemplatesService(IGenericRepository<EmailTemplete> emailTemplateRepository, IMapper _mapper) : IEmailTemplatesService
 {
-    
+    public PageListResponse<EmailTemplatesResponseDto> GetAllEmailTemplates(PageListRequest pageListRequest)
+    {
+        IQueryable<EmailTemplete> emailTempletes = emailTemplateRepository.GetQueryableInclude().Where(x => x.IsDeleted == false);
+        if (!string.IsNullOrEmpty(pageListRequest.SortColumn))
+        {
+            // Check if property exists
+            var propertyInfo = typeof(EmailTemplete).GetProperty(
+                pageListRequest.SortColumn,
+                BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance
+            );
+
+            if (propertyInfo == null)
+            {
+                throw new AppException(
+                    string.Format(Constants.INVALID_COLUMN_NAME, pageListRequest.SortColumn),400);
+            }
+
+            // If the property is boolean, invert the sort direction
+            if (propertyInfo?.PropertyType == typeof(bool))
+            {
+                pageListRequest.SortDescending = !pageListRequest.SortDescending;
+            }
+            emailTempletes = emailTempletes.OrderBy($"{pageListRequest.SortColumn} {(pageListRequest.SortDescending ? "desc" : "asc")}");
+        }
+        else
+        {
+            emailTempletes = emailTempletes.OrderBy(q => q.Id);
+        }
+
+        List<EmailTemplete> emailTempletesList = emailTempletes.ToList();
+
+        List<EmailTemplatesResponseDto> emailTemplatesResponse = _mapper.Map<List<EmailTemplatesResponseDto>>(emailTempletesList);
+
+
+        return new PageListResponse<EmailTemplatesResponseDto>
+        {
+            Records = emailTemplatesResponse,
+            TotalRecords = emailTempletesList.Count(),
+        };
+    }
 }

--- a/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
+++ b/QuizVerse.Application/Core/Service/EmailTemplatesService.cs
@@ -39,7 +39,6 @@ public class EmailTemplatesService(IGenericRepository<EmailTemplete> emailTempla
 
         List<EmailTemplatesResponseDto> emailTemplatesResponse = _mapper.Map<List<EmailTemplatesResponseDto>>(emailTempletes.ToList());
 
-
         return new PageListResponse<EmailTemplatesResponseDto>
         {
             Records = emailTemplatesResponse,

--- a/QuizVerse.Infrastructure/Mappings/MappingProfile.cs
+++ b/QuizVerse.Infrastructure/Mappings/MappingProfile.cs
@@ -207,6 +207,10 @@ public class MappingProfile : Profile
             .ForMember(dest => dest.BattleName, opt => opt.MapFrom(src => CapitalizeFirst(src.BattleName)))
             .ForMember(dest => dest.Description, opt => opt.MapFrom(src => ToTitleCase(src.Description)));
         #endregion
+
+        #region Email Templates
+        CreateMap<EmailTemplete, EmailTemplatesResponseDto>();
+        #endregion
     }
 
     private static string ToTitleCase(string input) =>

--- a/QuizVerse.UnitTests/Services/EmailTemplatesServiceTest.cs
+++ b/QuizVerse.UnitTests/Services/EmailTemplatesServiceTest.cs
@@ -1,6 +1,245 @@
+using AutoMapper;
+using Moq;
+using QuizVerse.Application.Core.Service;
+using QuizVerse.Domain.Entities;
+using QuizVerse.Infrastructure.Common.Exceptions;
+using QuizVerse.Infrastructure.DTOs.RequestDTOs;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+using QuizVerse.Infrastructure.Interface;
+using Xunit;
+
 namespace QuizVerse.UnitTests.Services;
 
 public class EmailTemplatesServiceTest
 {
-    
+    private readonly Mock<IGenericRepository<EmailTemplete>> _emailTemplateRepositoryMock;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly EmailTemplatesService _emailTemplatesService;
+
+    public EmailTemplatesServiceTest()
+    {
+        _emailTemplateRepositoryMock = new Mock<IGenericRepository<EmailTemplete>>();
+        _mapperMock = new Mock<IMapper>();
+        _emailTemplatesService = new EmailTemplatesService(_emailTemplateRepositoryMock.Object, _mapperMock.Object);
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_DefaultSorting_ReturnsAllTemplates()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = null,
+            SortDescending = false
+        };
+
+        var emailTemplates = new List<EmailTemplete>
+        {
+            new EmailTemplete { Id = 1, Title = "Template1", IsDeleted = false },
+            new EmailTemplete { Id = 2, Title = "Template2", IsDeleted = false }
+        }.AsQueryable();
+
+        var mappedTemplates = new List<EmailTemplatesResponseDto>
+        {
+            new EmailTemplatesResponseDto { Id = 1, Title = "Template1" },
+            new EmailTemplatesResponseDto { Id = 2, Title = "Template2" }
+        };
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()))
+            .Returns(mappedTemplates);
+
+        // Act
+        var result = _emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.TotalRecords);
+        Assert.Equal(mappedTemplates, result.Records);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_SortByValidColumnAscending_ReturnsSortedTemplates()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = "Title",
+            SortDescending = false
+        };
+
+        var emailTemplates = new List<EmailTemplete>
+        {
+            new EmailTemplete { Id = 1, Title = "TemplateB", IsDeleted = false },
+            new EmailTemplete { Id = 2, Title = "TemplateA", IsDeleted = false }
+        }.AsQueryable();
+
+        var mappedTemplates = new List<EmailTemplatesResponseDto>
+        {
+            new EmailTemplatesResponseDto { Id = 2, Title = "TemplateA" },
+            new EmailTemplatesResponseDto { Id = 1, Title = "TemplateB" }
+        };
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()))
+            .Returns(mappedTemplates);
+
+        // Act
+        var result = _emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.TotalRecords);
+        Assert.Equal("TemplateA", result.Records[0].Title);
+        Assert.Equal("TemplateB", result.Records[1].Title);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_SortByValidColumnDescending_ReturnsSortedTemplates()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = "Title",
+            SortDescending = true
+        };
+
+        var emailTemplates = new List<EmailTemplete>
+        {
+            new EmailTemplete { Id = 1, Title = "TemplateB", IsDeleted = false },
+            new EmailTemplete { Id = 2, Title = "TemplateA", IsDeleted = false }
+        }.AsQueryable();
+
+        var mappedTemplates = new List<EmailTemplatesResponseDto>
+        {
+            new EmailTemplatesResponseDto { Id = 1, Title = "TemplateB" },
+            new EmailTemplatesResponseDto { Id = 2, Title = "TemplateA" }
+        };
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()))
+            .Returns(mappedTemplates);
+
+        // Act
+        var result = _emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.TotalRecords);
+        Assert.Equal("TemplateB", result.Records[0].Title);
+        Assert.Equal("TemplateA", result.Records[1].Title);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_SortByBooleanColumn_InvertsSortDirection()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = "IsDeleted",
+            SortDescending = true // Should be inverted to ascending
+        };
+
+        var emailTemplates = new List<EmailTemplete>
+        {
+            new EmailTemplete { Id = 1, Title = "Template1", IsDeleted = false },
+            new EmailTemplete { Id = 2, Title = "Template2", IsDeleted = false }
+        }.AsQueryable();
+
+        var mappedTemplates = new List<EmailTemplatesResponseDto>
+        {
+            new EmailTemplatesResponseDto { Id = 1, Title = "Template1" },
+            new EmailTemplatesResponseDto { Id = 2, Title = "Template2" }
+        };
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()))
+            .Returns(mappedTemplates);
+
+        // Act
+        var result = _emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(2, result.TotalRecords);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Once());
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_InvalidSortColumn_ThrowsArgumentException()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = "InvalidColumn",
+            SortDescending = false
+        };
+
+        var emailTemplates = new List<EmailTemplete>().AsQueryable();
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        // Act & Assert
+        var exception = Assert.Throws<AppException>(() => _emailTemplatesService.GetAllEmailTemplates(pageListRequest));
+        Assert.Equal("Invalid sort column 'InvalidColumn'. The property does not exist.", exception.Message);
+        Assert.Equal(400, exception.StatusCode);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Never());
+    }
+
+    [Fact]
+    public void GetAllEmailTemplates_NoTemplates_ReturnsEmptyList()
+    {
+        // Arrange
+        var pageListRequest = new PageListRequest
+        {
+            SortColumn = null,
+            SortDescending = false
+        };
+
+        var emailTemplates = new List<EmailTemplete>().AsQueryable();
+
+        _emailTemplateRepositoryMock
+            .Setup(repo => repo.GetQueryableInclude())
+            .Returns(emailTemplates);
+
+        _mapperMock
+            .Setup(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()))
+            .Returns(new List<EmailTemplatesResponseDto>());
+
+        // Act
+        var result = _emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.Records);
+        Assert.Equal(0, result.TotalRecords);
+        _emailTemplateRepositoryMock.Verify(repo => repo.GetQueryableInclude(), Times.Once());
+        _mapperMock.Verify(mapper => mapper.Map<List<EmailTemplatesResponseDto>>(It.IsAny<List<EmailTemplete>>()), Times.Once());
+    }
 }

--- a/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
+++ b/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
@@ -1,11 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using QuizVerse.Application.Core.Interface;
+using QuizVerse.Infrastructure.ApiResponse;
+using QuizVerse.Infrastructure.Common;
+using QuizVerse.Infrastructure.DTOs.RequestDTOs;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+using QuizVerse.Infrastructure.Enums;
 
 namespace QuizVerse.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize(Roles = nameof(UserRoles.Admin))]
 public class EmailTemplatesController() : ControllerBase
 {
-    
+    [HttpGet("get-all-email-templates")]
+    public IActionResult GetAllEmailTemplates([FromServices] IEmailTemplatesService emailTemplatesService, [FromQuery] PageListRequest pageListRequest)
+    {
+        var response = emailTemplatesService.GetAllEmailTemplates(pageListRequest);
+        
+        return Ok(new ApiResponse<PageListResponse<EmailTemplatesResponseDto>>
+        {
+            Result = true,
+            Message = Constants.FETCH_SUCCESS,
+            StatusCode = 200,
+            Data = emailTemplatesService.GetAllEmailTemplates(pageListRequest)
+        });
+    }
 }

--- a/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
+++ b/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
@@ -11,7 +11,7 @@ namespace QuizVerse.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-// [Authorize(Roles = nameof(UserRoles.Admin))]
+[Authorize(Roles = nameof(UserRoles.Admin))]
 public class EmailTemplatesController(IEmailTemplatesService emailTemplatesService) : ControllerBase
 {
     [HttpPost("get-all-email-templates")]

--- a/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
+++ b/QuizVerse.WebAPI/Controllers/EmailTemplatesController.cs
@@ -11,14 +11,12 @@ namespace QuizVerse.WebAPI.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
-[Authorize(Roles = nameof(UserRoles.Admin))]
-public class EmailTemplatesController() : ControllerBase
+// [Authorize(Roles = nameof(UserRoles.Admin))]
+public class EmailTemplatesController(IEmailTemplatesService emailTemplatesService) : ControllerBase
 {
-    [HttpGet("get-all-email-templates")]
-    public IActionResult GetAllEmailTemplates([FromServices] IEmailTemplatesService emailTemplatesService, [FromQuery] PageListRequest pageListRequest)
+    [HttpPost("get-all-email-templates")]
+    public IActionResult GetAllEmailTemplates(PageListRequest pageListRequest)
     {
-        var response = emailTemplatesService.GetAllEmailTemplates(pageListRequest);
-        
         return Ok(new ApiResponse<PageListResponse<EmailTemplatesResponseDto>>
         {
             Result = true,


### PR DESCRIPTION
In this PR i have completed the Sprint 3 BE task of to created the api to get the email templates list form db with sorting functionality to it.

--Api Response
<img width="1439" height="598" alt="{F9A51283-8B87-461B-A751-626D6A134AEC}" src="https://github.com/user-attachments/assets/e4917885-e644-49f2-a88f-95d85f37de3c" />
<img width="1435" height="811" alt="{B653284D-1F86-4B91-8DAA-53C43060563D}" src="https://github.com/user-attachments/assets/b4ab9721-869c-4e3e-a167-8e1ff0e9ea27" />
 
 --Test Cases 
<img width="332" height="851" alt="image" src="https://github.com/user-attachments/assets/fc4a25aa-e803-4748-a47a-5119f2b0ee17" />
<img width="1009" height="292" alt="image" src="https://github.com/user-attachments/assets/3e8303d3-f345-45bb-aa63-cc7eafa63d9c" />

