### PR TITLE
Adding api for user recent battle data

### DIFF
--- a/QuizVerse.Application/Core/Interface/IUserBattlesService.cs
+++ b/QuizVerse.Application/Core/Interface/IUserBattlesService.cs
@@ -1,5 +1,8 @@
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+
 namespace QuizVerse.Application.Core.Interface;
 
 public interface IUserBattlesService
 {
+    Task<List<UserRecentBattleDto>> GetUserRecentBattles();
 }

--- a/QuizVerse.Application/Core/Service/UserBattlesService.cs
+++ b/QuizVerse.Application/Core/Service/UserBattlesService.cs
@@ -1,7 +1,35 @@
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Npgsql;
+using NpgsqlTypes;
 using QuizVerse.Application.Core.Interface;
+using QuizVerse.Infrastructure.Common;
+using QuizVerse.Infrastructure.Common.Helper;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+using QuizVerse.Infrastructure.Enums;
+using QuizVerse.Infrastructure.Interface;
 
 namespace QuizVerse.Application.Core.Service;
 
-public class UserBattlesService : IUserBattlesService
+public class UserBattlesService(IHttpContextAccessor httpContextAccessor, ISqlQueryRepository sqlQueryRepository, IMapper mapper) : IUserBattlesService
 {
+    public int UserId => httpContextAccessor.HttpContext?.User?.GetUserId() ?? throw new UnauthorizedAccessException(Constants.UNAUTHORIZED_USER);
+
+    public async Task<List<UserRecentBattleDto>> GetUserRecentBattles()
+    {
+        var query = string.Format(SqlConstants.GET_USER_RECENT_BATTLES_QUERY_TEMPLATE,
+                                  SqlConstants.GET_USER_RECENT_BATTLES_FUNCTION);
+
+        var parameters = new NpgsqlParameter[]
+        {
+        new("p_user_id", NpgsqlDbType.Integer) { Value = UserId },
+        new("p_status_draw", NpgsqlDbType.Integer) { Value = (int)BattleStatus.Draw },
+        new("p_status_completed", NpgsqlDbType.Integer) { Value = (int)BattleStatus.Completed }
+        };
+
+        var rawResult = await sqlQueryRepository.SqlQueryListAsync<UserRecentBattleDto>(query, parameters);
+
+        return mapper.Map<List<UserRecentBattleDto>>(rawResult);
+    }
+
 }

--- a/QuizVerse.Domain/DatabaseScripts/Functions/get_user_recent_battles.sql
+++ b/QuizVerse.Domain/DatabaseScripts/Functions/get_user_recent_battles.sql
@@ -1,0 +1,70 @@
+-- =============================================
+-- Author:       <Devisha Gajjar>
+-- Create date:  <03-Sep-2025>
+-- Description:  <Get recent battles of a user including
+--               opponent, category, result, score, XP, and profile pic>
+-- Usage:        SELECT * FROM get_user_recent_battles(2, 2, 1);
+-- =============================================
+
+CREATE OR REPLACE FUNCTION get_user_recent_battles(
+    p_user_id INT,             -- ID of the current user
+    p_status_draw INT,         -- Enum value for Draw (BattleStatus.Draw)
+    p_status_completed INT     -- Enum value for Completed (BattleStatus.Completed)
+)
+RETURNS TABLE (
+    "Opponent" VARCHAR,
+    "ProfilePic" VARCHAR,
+    "Category" VARCHAR,
+    "Result" VARCHAR,
+    "YourScore" INT,
+    "OpponentScore" INT,
+    "XpGained" INT
+)
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT 
+        -- Opponent name and profile pic
+        CASE WHEN bs.user1_id = p_user_id THEN u2.full_name ELSE u1.full_name END::VARCHAR AS "Opponent",
+        CASE WHEN bs.user1_id = p_user_id THEN u2.profile_pic ELSE u1.profile_pic END::VARCHAR AS "ProfilePic",
+
+        -- Quiz category name
+        qc.category_name::VARCHAR AS "Category",
+
+        -- Battle result (casted to match return type)
+        CASE
+            WHEN bs.battle_status = p_status_draw THEN 'Draw'::VARCHAR
+            WHEN bs.battle_status = p_status_completed AND br.winner_id = p_user_id THEN 'Won'::VARCHAR
+            WHEN bs.battle_status = p_status_completed AND br.winner_id IS NOT NULL THEN 'Lost'::VARCHAR
+            ELSE 'Unknown'::VARCHAR
+        END AS "Result",
+
+        -- Scores
+        CASE WHEN bs.user1_id = p_user_id THEN br.user1_corrected_ans ELSE br.user2_corrected_ans END AS "YourScore",
+        CASE WHEN bs.user1_id = p_user_id THEN br.user2_corrected_ans ELSE br.user1_corrected_ans END AS "OpponentScore",
+
+        -- XP gained
+        CASE
+            WHEN bs.battle_status = p_status_draw THEN br.winner_gained_xp
+            WHEN bs.battle_status = p_status_completed AND br.winner_id = p_user_id THEN br.winner_gained_xp
+            WHEN bs.battle_status = p_status_completed AND br.winner_id IS NOT NULL THEN br.looser_gained_xp
+            ELSE 0
+        END AS "XpGained"
+
+    FROM "BattleResult" br
+    JOIN "BattleStatus" bs ON bs.id = br.battle_status
+    JOIN "BattleList" bl ON bs.battle_id = bl.id
+    JOIN "Quiz" q ON bl.quiz_id = q.id
+    JOIN "QuizCategory" qc ON q.category_id = qc.id
+    JOIN "Users" u1 ON bs.user1_id = u1.id
+    JOIN "Users" u2 ON bs.user2_id = u2.id
+
+    WHERE (bs.user1_id = p_user_id OR bs.user2_id = p_user_id)
+      AND (bs.battle_status = p_status_draw OR bs.battle_status = p_status_completed)
+
+    ORDER BY bs.modified_date DESC
+    LIMIT 10;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT * FROM get_user_recent_battles(12, 2, 1);

--- a/QuizVerse.Infrastructure/Common/SqlConstants.cs
+++ b/QuizVerse.Infrastructure/Common/SqlConstants.cs
@@ -76,4 +76,10 @@ public class SqlConstants
     public const string UPDATE_USER_PROFILE_FUNCTION = "update_user_setting";
     public const string UPDATE_USER_PROFILE_QUERY_TEMPLATE = "SELECT * FROM {0}(@p_current_user_id, @p_new_email, @p_new_name, @p_new_bio)";
     #endregion
+
+    #region UserBattles
+    public const string GET_USER_RECENT_BATTLES_FUNCTION = "get_user_recent_battles";
+    public const string GET_USER_RECENT_BATTLES_QUERY_TEMPLATE = "SELECT * FROM {0}(@p_user_id, @p_status_draw, @p_status_completed)";
+    #endregion
+
 }

--- a/QuizVerse.Infrastructure/Mappings/MappingProfile.cs
+++ b/QuizVerse.Infrastructure/Mappings/MappingProfile.cs
@@ -287,6 +287,14 @@ public class MappingProfile : Profile
                 opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.Bio) ? null : src.Bio.Trim()));
 
         #endregion
+
+        #region UserBattles
+        CreateMap<UserRecentBattleDto, UserRecentBattleDto>()
+            .ForMember(dest => dest.Opponent,
+                opt => opt.MapFrom(src => ToTitleCase(src.Opponent)))
+            .ForMember(dest => dest.Category,
+                opt => opt.MapFrom(src => ToTitleCase(src.Category)));
+        #endregion
     }
 
     private static string ToTitleCase(string input) =>

--- a/QuizVerse.UnitTests/Services/EmailTemplatesServiceTest.cs
+++ b/QuizVerse.UnitTests/Services/EmailTemplatesServiceTest.cs
@@ -13,7 +13,7 @@ using System.Linq.Expressions;
 using System.Security.Claims;
 using Xunit;
 
-namespace QuizVerse.Application.Core.Tests
+namespace QuizVerse.UnitTests.Services
 {
     public class EmailTemplatesServiceTests
     {

--- a/QuizVerse.UnitTests/Services/UserBattlesServiceTest.cs
+++ b/QuizVerse.UnitTests/Services/UserBattlesServiceTest.cs
@@ -1,5 +1,92 @@
-namespace QuizVerse.UnitTests.Services;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Npgsql;
+using QuizVerse.Application.Core.Service;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
+using QuizVerse.Infrastructure.Interface;
+using AutoMapper;
+using Xunit;
 
-public class UserBattlesServiceTest
+namespace QuizVerse.UnitTests.Services
 {
+    public class UserBattlesServiceTest
+    {
+        private readonly Mock<IHttpContextAccessor> _mockHttpContextAccessor;
+        private readonly Mock<ISqlQueryRepository> _mockSqlQueryRepository;
+        private readonly Mock<IMapper> _mockMapper;
+        private readonly UserBattlesService _service;
+
+        public UserBattlesServiceTest()
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.UserData, "2")], "mock"));
+
+            _mockHttpContextAccessor = new Mock<IHttpContextAccessor>();
+            _mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(httpContext);
+
+            _mockSqlQueryRepository = new Mock<ISqlQueryRepository>();
+            _mockMapper = new Mock<IMapper>();
+
+            _service = new UserBattlesService(
+                _mockHttpContextAccessor.Object,
+                _mockSqlQueryRepository.Object,
+                _mockMapper.Object);
+        }
+
+        [Fact]
+        public async Task GetUserRecentBattles_ReturnsMappedBattleList()
+        {
+            var rawBattles = new List<UserRecentBattleDto>
+            {
+                new()
+                {
+                    Opponent = "opponent 1",
+                    Category = "general knowledge",
+                    Result = "Won",
+                    YourScore = 8,
+                    OpponentScore = 6,
+                    XpGained = 10
+                }
+            };
+
+            var mappedBattles = new List<UserRecentBattleDto>
+            {
+                new()
+                {
+                    Opponent = "Opponent 1",
+                    Category = "General Knowledge",
+                    Result = "Won",
+                    YourScore = 8,
+                    OpponentScore = 6,
+                    XpGained = 10
+                }
+            };
+
+            _mockSqlQueryRepository
+                .Setup(repo => repo.SqlQueryListAsync<UserRecentBattleDto>(
+                    It.IsAny<string>(),
+                    It.IsAny<NpgsqlParameter[]>()))
+                .ReturnsAsync(rawBattles);
+
+            _mockMapper
+                .Setup(m => m.Map<List<UserRecentBattleDto>>(rawBattles))
+                .Returns(mappedBattles);
+
+            var result = await _service.GetUserRecentBattles();
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal("Opponent 1", result[0].Opponent);
+            Assert.Equal("General Knowledge", result[0].Category);
+            Assert.Equal(8, result[0].YourScore);
+
+            _mockSqlQueryRepository.Verify(repo =>
+                repo.SqlQueryListAsync<UserRecentBattleDto>(It.IsAny<string>(), It.IsAny<NpgsqlParameter[]>()), Times.Once);
+
+            _mockMapper.Verify(mapper =>
+                mapper.Map<List<UserRecentBattleDto>>(rawBattles), Times.Once);
+        }
+    }
 }

--- a/QuizVerse.WebAPI/Controllers/UserBattlesController.cs
+++ b/QuizVerse.WebAPI/Controllers/UserBattlesController.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using QuizVerse.Application.Core.Interface;
+using QuizVerse.Infrastructure.ApiResponse;
+using QuizVerse.Infrastructure.Common;
+using QuizVerse.Infrastructure.DTOs.ResponseDTOs;
 using QuizVerse.Infrastructure.Enums;
 
 namespace QuizVerse.WebAPI.Controllers;
@@ -10,4 +13,15 @@ namespace QuizVerse.WebAPI.Controllers;
 [Route("api/[controller]")]
 public class UserBattlesController(IUserBattlesService userBattlesService) : ControllerBase
 {
+    [HttpGet("get-user-recent-battles")]
+    public async Task<IActionResult> GetUserRecentBattles()
+    {
+        return Ok(new ApiResponse<List<UserRecentBattleDto>>
+        {
+            Result = true,
+            Message = Constants.FETCH_SUCCESS,
+            StatusCode = StatusCodes.Status200OK,
+            Data = await userBattlesService.GetUserRecentBattles()
+        });
+    }
 }


### PR DESCRIPTION
Adding a api for user last 10 recent battle data 

-- test cases
<img width="328" height="519" alt="image" src="https://github.com/user-attachments/assets/567dac02-8d65-4d6e-9b12-d477816328f1" />


-- user has battle data 
<img width="1492" height="580" alt="image" src="https://github.com/user-attachments/assets/5637e2eb-87e8-40c8-b850-55908bb0da04" />
<img width="1453" height="720" alt="image" src="https://github.com/user-attachments/assets/dc77d0ca-fa12-4399-834a-ce6f17d2688f" />


-- user has no battle data
<img width="1483" height="913" alt="image" src="https://github.com/user-attachments/assets/0f4d5d47-da37-444a-896d-948f8462e829" />

